### PR TITLE
Check for subsequent sample_prof_start calls

### DIFF
--- a/sample_prof.c
+++ b/sample_prof.c
@@ -91,7 +91,7 @@ static void sample_prof_start(long interval_usec, size_t num_entries_alloc) {
 	zend_sample_prof_globals *g = SAMPLE_PROF_G;
 
 	if (g->enabled) {
-		zend_throw_exception(NULL, "The profiling is already running", 0);
+		zend_throw_exception(NULL, "Profiling is already enabled", 0);
 		return;
 	}
 
@@ -234,4 +234,3 @@ zend_module_entry sample_prof_module_entry = {
 #ifdef COMPILE_DL_SAMPLE_PROF
 ZEND_GET_MODULE(sample_prof)
 #endif
-

--- a/sample_prof.c
+++ b/sample_prof.c
@@ -90,6 +90,11 @@ retry_later:
 static void sample_prof_start(long interval_usec, size_t num_entries_alloc) {
 	zend_sample_prof_globals *g = SAMPLE_PROF_G;
 
+	if (g->enabled) {
+		zend_throw_exception(NULL, "The profiling is already running", 0);
+		return;
+	}
+
 	/* Initialize data structures for entries */
 	if (g->entries) {
 		efree(g->entries);


### PR DESCRIPTION
There was no check for `g->enabled` neither in the `sample_prof_start`. As a result, subsequent calls to `sample_prof_start`may result in Segmentation fault (one thread is cancelled only, and another is trying to access memory freed in shutdown function).

PS. My internal perfectionist could not ignore this. I apologize for distracting you with such an unnecessary (in most cases) patch.